### PR TITLE
Fixing the `exampleRecordID` hardcoded key for the example row

### DIFF
--- a/src/components/AuthenticatedViews/ResearcherHome/CreateDatasetForm/CreateDatasetForm.tsx
+++ b/src/components/AuthenticatedViews/ResearcherHome/CreateDatasetForm/CreateDatasetForm.tsx
@@ -74,7 +74,7 @@ const CreateDatasetForm = () => {
       status: DatasetStatus.Saving,
       activeVersion: 0,
       register: {
-        exampleRecordID: {
+        [crypto.randomUUID()]: {
           SampleID: { displayValue: '', dataValue: '', version: '0' },
           'Detection ID': { displayValue: '', dataValue: '', version: '0' },
           'Organism Nickname': {


### PR DESCRIPTION
Closes #3