### PR TITLE
Fix "aria-describedby" warning in test

### DIFF
--- a/src/components/DataPage/FilterPanel/components.tsx
+++ b/src/components/DataPage/FilterPanel/components.tsx
@@ -189,7 +189,7 @@ const DateRange = ({
   const isStartDateInvalid = !startDateFilter.valid
   const isEndDateInvalid = !endDateFilter.valid
 
-  // Used for aria-described-by
+  // Used for aria-describedby
   const tooltipId = useMemo(
     () => `date-range-tooltip-${Math.random().toString(36).slice(2)}`,
     []
@@ -265,7 +265,7 @@ const DateInput = ({
     <DateInputStyled
       type={'date'}
       aria-label={ariaLabel}
-      aria-described-by={ariaDescribedBy}
+      aria-describedby={ariaDescribedBy}
       min={dateMin}
       max={dateMax}
       value={value}


### PR DESCRIPTION
I misspelled "aria-describedby", which made the test suite produce this error:

<img width="1041" alt="image" src="https://github.com/talus-analytics-bus/pharos-frontend/assets/130925/9791d250-7347-4cfb-bca1-3739a96559d4">

This PR fixes the typo and removes warning