### PR TITLE
Make typeahead chip narrower

### DIFF
--- a/src/components/DataPage/FilterPanel/FilterTypeahead.tsx
+++ b/src/components/DataPage/FilterPanel/FilterTypeahead.tsx
@@ -15,7 +15,7 @@ const SelectedTypeaheadValues = styled.ul`
   margin-top: 10px;
   list-style: none;
   padding: 0;
-  margin-right: 22px;
+  margin-right: 44px;
   display: flex;
   flex-flow: column nowrap;
   align-items: flex-start;


### PR DESCRIPTION
Before:
<img width="403" alt="image" src="https://github.com/talus-analytics-bus/pharos-frontend/assets/130925/0fbd7ff1-f88a-4fdb-a13f-1009fd82c6d8">


After: 
<img width="400" alt="image" src="https://github.com/talus-analytics-bus/pharos-frontend/assets/130925/52d8be94-9984-4e5f-9866-db53b809dbb0">
